### PR TITLE
Fix: Use the return of the isValid method to validate a card

### DIFF
--- a/src/hipay-fullservice-sdk.js
+++ b/src/hipay-fullservice-sdk.js
@@ -1069,19 +1069,19 @@ var HiPay = (function (HiPay) {
                     isPotentiallyValid = true;
                 }
 
-                if (serviceCreditCard.idType == 'card_maestro_info' && creditCardCVVString == "") {
+                if (serviceCreditCard.idType == _idProductAPIMapper.bcmc && creditCardCVVString == "") {
                     isPotentiallyValid = true;
                 }
 
                 if (isPotentiallyValid == false) {
-                    validatorCreditCardCVV.isValid(creditCardCVVString);
+                    isPotentiallyValid = validatorCreditCardCVV.isValid(creditCardCVVString);
                 }
 
                 return isPotentiallyValid;
             };
 
             validatorCreditCardCVV.isValid = function (creditCardCVVString) {
-                if (serviceCreditCard.idType == 'card_maestro_info') {
+                if (serviceCreditCard.idType == _idProductAPIMapper.bcmc) {
                     return true;
                 }
 


### PR DESCRIPTION
Hello @jprotin ,

-----------------------------------------
**_Environment_**:
all

-----------------------------------------
**_Issue_**:

There is a bug when we use a form with a cvv field like amex and complete it, then modify the card number field with a BCMC cardnumber, the SDK doest not valid the CVV even if for BCMC there is no CVV.
This happens because the SDK doesn't use the return of the isValid method in the isPotentiallyValid method in the serviceCreditCard.validatorCreditCardCVV service.