### PR TITLE
Remove unwanted check on charcode in carholder keypress causing a loop when leaving the card holder field

### DIFF
--- a/src/hipay-fullservice-sdk.js
+++ b/src/hipay-fullservice-sdk.js
@@ -2037,13 +2037,11 @@ var HiPay = (function (HiPay) {
             var evt = e || window.event;
             var charCode = evt.keyCode || evt.which;
 
-            if (charCode == 8 || charCode == 46) {
-                if (evtIsPrintable(evt)) {
-                    if (!evt.ctrlKey) {
-                        evt.preventDefault ? evt.preventDefault() : evt.returnValue = false;
-                        _instanceServiceCreditCard = new _serviceCreditCard();
-                        _instanceServiceCreditCard.initCreditCardHolder(charCode);
-                    }
+            if (evtIsPrintable(evt)) {
+                if (!evt.ctrlKey) {
+                    evt.preventDefault ? evt.preventDefault() : evt.returnValue = false;
+                    _instanceServiceCreditCard = new _serviceCreditCard();
+                    _instanceServiceCreditCard.initCreditCardHolder(charCode);
                 }
             }
 
@@ -2051,7 +2049,7 @@ var HiPay = (function (HiPay) {
         };
         _addFieldListener(_selectElementWithHipayId(_idInputMapper[propt]), 'keypress', cardHolderHandlerKeypress, false);
 
-        var cardNumberHandlerChange = function (e) {
+        var cardHolderHandlerChange = function (e) {
             var evt = e || window.event;
 
             if (!evt.ctrlKey) {
@@ -2063,7 +2061,7 @@ var HiPay = (function (HiPay) {
             _instanceServiceCreditCard.initCreditCardHolder("");
             _callbackEventFormChange();
         };
-        _addFieldListener(_selectElementWithHipayId(_idInputMapper[propt]), 'change', cardNumberHandlerChange, false);
+        _addFieldListener(_selectElementWithHipayId(_idInputMapper[propt]), 'change', cardHolderHandlerChange, false);
 
         _initListenEvent(_idInputMapper[propt]);
     };


### PR DESCRIPTION
Hello @jprotin ,

-----------------------------------------
**_Environment_**:

Safari browser (all version)

-----------------------------------------
**_Issue_**:

On safari when changing the value and leaving the card holder field there is a "infinite loop" (not really infinite because it seems killed by the browser itself), 
```
'msg' => 'RangeError: Maximum call stack size exceeded.',
'line' => '2',
'column' => '12950',
```
